### PR TITLE
refactor: Move `reverse` and `sub` implementations out `uni.c`

### DIFF
--- a/makefile
+++ b/makefile
@@ -34,6 +34,7 @@ SRC = \
 	src/reverse.c \
 	src/segment_breaks.c \
 	src/segments.c \
+	src/sub.c \
 	src/uni.c
 
 LUASRC = \
@@ -84,9 +85,10 @@ src/is_segment_break.o: src/is_segment_break.c src/uni.h src/utf8.h makefile con
 src/count_segments.o: src/count_segments.c src/uni.h makefile config.mk
 src/match_n_segments.o: src/match_n_segments.c src/uni.h src/utf8.h makefile config.mk
 src/match_oneof_graphemes.o: src/match_oneof_graphemes.c src/uni.h src/utf8.h makefile config.mk
-src/reverse.o: src/reverse.c src/uni.h src/utf8.h makefile config.mk
+src/reverse.o: src/reverse.c src/uni.h makefile config.mk
 src/segment_breaks.o: src/segment_breaks.c src/uni.h makefile config.mk
 src/segments.o: src/segments.c src/uni.h makefile config.mk
+src/sub.o: src/sub.c src/uni.h makefile config.mk
 src/uni.o: src/uni.c src/uni.h makefile config.mk
 
 $(SRC:.c=.o):

--- a/makefile
+++ b/makefile
@@ -31,6 +31,7 @@ SRC = \
 	src/is_segment_break.c \
 	src/match_n_segments.c \
 	src/match_one_of_graphemes.c \
+	src/reverse.c \
 	src/segment_breaks.c \
 	src/segments.c \
 	src/uni.c
@@ -83,6 +84,7 @@ src/is_segment_break.o: src/is_segment_break.c src/uni.h src/utf8.h makefile con
 src/count_segments.o: src/count_segments.c src/uni.h makefile config.mk
 src/match_n_segments.o: src/match_n_segments.c src/uni.h src/utf8.h makefile config.mk
 src/match_oneof_graphemes.o: src/match_oneof_graphemes.c src/uni.h src/utf8.h makefile config.mk
+src/reverse.o: src/reverse.c src/uni.h src/utf8.h makefile config.mk
 src/segment_breaks.o: src/segment_breaks.c src/uni.h makefile config.mk
 src/segments.o: src/segments.c src/uni.h makefile config.mk
 src/uni.o: src/uni.c src/uni.h makefile config.mk

--- a/src/reverse.c
+++ b/src/reverse.c
@@ -1,0 +1,20 @@
+#include "uni.h"
+
+#include <grapheme.h>
+
+int reverse_graphemes(lua_State *L)
+{
+    size_t byte_len;
+    const char *src = luaL_checklstring(L, 1, &byte_len);
+
+    luaL_Buffer b;
+    char *dest = luaL_buffinitsize(L, &b, byte_len);
+
+    for (size_t offset = 0, inc; offset < byte_len; offset += inc) {
+        inc = grapheme_next_character_break_utf8(src + offset, byte_len - offset);
+        memcpy(dest + byte_len - offset - inc, src + offset, inc);
+    }
+
+    luaL_pushresultsize(&b, byte_len);
+    return 1;
+}

--- a/src/sub.c
+++ b/src/sub.c
@@ -1,0 +1,99 @@
+#include "uni.h"
+
+#include <grapheme.h>
+
+static inline size_t normalize_start_pos(lua_Integer pos, size_t len)
+{
+    if (pos > 0) {
+        return (size_t)pos;
+    }
+    else if (pos == 0) {
+        return 1;
+    }
+    else if (pos < -(lua_Integer)len) {
+        return 1;
+    }
+    else if (pos < 0) {
+        return (size_t)(len + pos + 1);
+    }
+
+    ASSERT_UNREACHABLE();
+}
+
+static inline size_t normalize_end_pos(lua_Integer pos, size_t len)
+{
+    if (pos > (lua_Integer)len) {
+        return len;
+    }
+    else if (pos >= 0) {
+        return pos;
+    }
+    else if (pos < -(lua_Integer)len) {
+        return 0;
+    }
+    else if (pos < 0) {
+        return len + pos + 1;
+    }
+
+    ASSERT_UNREACHABLE();
+}
+
+static size_t c_graphemes_sub(const char * restrict src, size_t src_len, char * restrict dest, size_t dest_len,
+    size_t start, size_t end)
+{
+    assert(start <= end);
+
+    size_t pos = 1;
+
+    // Skip over graphemes until we reach the start position
+    size_t src_off = 0;
+    while (pos < start && src_off < src_len) {
+        size_t inc = grapheme_next_character_break_utf8(src + src_off, src_len - src_off);
+        src_off += inc;
+        pos++;
+    }
+
+    // Copy graphemes until we reach the end position
+    size_t dest_off = 0;
+    while (pos <= end && src_off < src_len && dest_off < dest_len) {
+        size_t inc = grapheme_next_character_break_utf8(src + src_off, src_len - src_off);
+        if (dest != NULL) {
+            memcpy(dest + dest_off, src + src_off, inc);
+        }
+        src_off += inc;
+        dest_off += inc;
+        pos++;
+    }
+
+    return dest_off;
+}
+
+int graphemes_sub(lua_State *L)
+{
+    size_t byte_len;
+    const char *src = luaL_checklstring(L, 1, &byte_len);
+
+    size_t grapheme_count = c_count_graphemes(src, byte_len);
+
+    size_t start = normalize_start_pos(luaL_checkinteger(L, 2), grapheme_count);
+    size_t end = normalize_end_pos(luaL_optinteger(L, 3, -1), grapheme_count);
+
+    if (start > end) {
+        lua_pushliteral(L, "");
+        return 1;
+    }
+
+    // Null pass to determine the length of the substring
+    size_t dest_len = c_graphemes_sub(src, byte_len, NULL, SIZE_MAX, start, end);
+
+    luaL_Buffer b;
+    char *dest = luaL_buffinitsize(L, &b, dest_len);
+
+    // Effectively copy the substring into the buffer
+    size_t copied_len = c_graphemes_sub(src, byte_len, dest, dest_len, start, end);
+
+    assert(copied_len == dest_len);
+
+    luaL_pushresultsize(&b, dest_len);
+    return 1;
+}

--- a/src/uni.c
+++ b/src/uni.c
@@ -1,34 +1,6 @@
 #include "uni.h"
 
-#include <assert.h>
-#include <stdlib.h>
-#include <string.h>
-
 #include <grapheme.h>
-
-static int uni_reverse(lua_State *L)
-{
-    // Retrieve the source string and its length
-    size_t byte_len;
-    const char *src = luaL_checklstring(L, 1, &byte_len);
-
-    // Prepare the destination buffer
-    luaL_Buffer b;
-    char *dest = luaL_buffinitsize(L, &b, byte_len);
-
-    // Iterate over the source string
-    for (size_t offset = 0, inc; offset < byte_len; offset += inc) {
-        inc = grapheme_next_character_break_utf8(src + offset, byte_len - offset);
-
-        // Copy to the end of the destination buffer
-        memcpy(dest + byte_len - offset - inc, src + offset, inc);
-    }
-
-    // Push the destination string onto the stack
-    luaL_pushresultsize(&b, byte_len);
-
-    return 1;
-}
 
 static inline size_t normalize_start_pos(lua_Integer pos, size_t len)
 {
@@ -140,7 +112,7 @@ static luaL_Reg funcs[] = {
     {"_match_one_of_graphemes", match_one_of_graphemes},
     {        "grapheme_breaks",        grapheme_breaks},
     {              "graphemes",              graphemes},
-    {                "reverse",            uni_reverse},
+    {                "reverse",      reverse_graphemes},
     {                    "sub",                uni_sub},
     {                     NULL,                   NULL}
 };

--- a/src/uni.h
+++ b/src/uni.h
@@ -2,6 +2,8 @@
 #define UNI_H
 
 #include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include <lauxlib.h>
 #include <lua.h>
@@ -13,16 +15,18 @@ int lower(lua_State *);
 int upper(lua_State *);
 int title(lua_State *);
 
+int reverse_graphemes(lua_State *);
+
 size_t c_count_graphemes(const char *, size_t);
 int count_graphemes(lua_State *);
 int count_lines(lua_State *);
 int count_words(lua_State *);
 int count_sentences(lua_State *);
 
-int is_grapheme_break(lua_State *L);
-int is_line_break(lua_State *L);
-int is_word_break(lua_State *L);
-int is_sentence_break(lua_State *L);
+int is_grapheme_break(lua_State *);
+int is_line_break(lua_State *);
+int is_word_break(lua_State *);
+int is_sentence_break(lua_State *);
 
 int grapheme_breaks(lua_State *);
 int line_breaks(lua_State *);

--- a/src/uni.h
+++ b/src/uni.h
@@ -16,6 +16,7 @@ int upper(lua_State *);
 int title(lua_State *);
 
 int reverse_graphemes(lua_State *);
+int graphemes_sub(lua_State *);
 
 size_t c_count_graphemes(const char *, size_t);
 int count_graphemes(lua_State *);


### PR DESCRIPTION
With this change, `uni.c` now only contains module initialization logic.